### PR TITLE
fix sending with ASPEmail

### DIFF
--- a/ajaxed/class_email/email.asp
+++ b/ajaxed/class_email/email.asp
@@ -312,6 +312,9 @@ class Email
 	'******************************************************************************************************************
 	private function sendWithAspEmail()
 		mailer.charset = "utf-8"
+		if mailServer <> "" then
+			mailer.Host = mailServer
+		end if
 		on error resume next
 			sendWithAspEmail = mailer.send()
 			if err <> 0 then


### PR DESCRIPTION
this forces setting the host on the AspEmail, this fixes the "No SMTP Host Specified" Error
